### PR TITLE
Correct title casing for FAIR Software Route

### DIFF
--- a/src/lib/content/resources.json
+++ b/src/lib/content/resources.json
@@ -33,7 +33,7 @@
   },
   {
     "id": "r6",
-    "title": "Fair Software Route",
+    "title": "FAIR Software Route",
     "abstract": "Step-by-step interactive guide to making your research software FAIR.",
     "type": "Tool",
     "source": "External",


### PR DESCRIPTION
Just a minor correction, since FAIR is an acronym. Otherwise, the pages look fantastic!